### PR TITLE
Feat/add user model validation

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,2 +1,12 @@
 class User < ApplicationRecord
+  validates :name,
+            presence: true,
+            length: { minimum: 2, maximum: 12 }
+
+  VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-]+(\.[a-z\d\-]+)*\.[a-z]+\z/i.freeze
+  validates :email,
+            presence: true,
+            length: { maximum: 255 },
+            format: { with: VALID_EMAIL_REGEX },
+            uniqueness: { case_sensitive: false }
 end

--- a/db/migrate/20200728020553_add_index_email_to_users.rb
+++ b/db/migrate/20200728020553_add_index_email_to_users.rb
@@ -1,0 +1,5 @@
+class AddIndexEmailToUsers < ActiveRecord::Migration[6.0]
+  def change
+    add_index :users, :email, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_08_033844) do
+ActiveRecord::Schema.define(version: 2020_07_28_020553) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -20,6 +20,7 @@ ActiveRecord::Schema.define(version: 2020_07_08_033844) do
     t.string "email"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.index ["email"], name: "index_users_on_email", unique: true
   end
 
 end


### PR DESCRIPTION
close https://github.com/zskteam-20200726-121500/zsksample_rails01/issues/20

## 概要

Userモデルにバリデーションを追加
  - nameカラム
    - 存在性、最小2、最大12文字
  - emailカラム
    - 存在性、最大255文字、正しいemail、一意性

上記のバリデーションを実装して bundle exec rubocop とすると、「一意性のバリデーションを追加する際には、マイグレーションファイルでも一意性制約が必要」という指摘がされたため、マイグレーションファイルも追加

## 修正内容の検証方法

- ユーザー作成や更新時に、無効なnameやemailで保存しようとすると、バリデーションエラーが発生するようになる

## この修正が正しい理由

- ユーザー新規作成画面や編集画面で、無効な入力をした時、エラーメッセージが表示されることを確認
- rubocopやrspecが通る