### PR TITLE
Feat: add micropost files

### DIFF
--- a/app/assets/stylesheets/microposts.scss
+++ b/app/assets/stylesheets/microposts.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the microposts controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: https://sass-lang.com/

--- a/app/controllers/microposts_controller.rb
+++ b/app/controllers/microposts_controller.rb
@@ -1,0 +1,2 @@
+class MicropostsController < ApplicationController
+end

--- a/app/helpers/microposts_helper.rb
+++ b/app/helpers/microposts_helper.rb
@@ -1,0 +1,2 @@
+module MicropostsHelper
+end

--- a/app/models/micropost.rb
+++ b/app/models/micropost.rb
@@ -1,0 +1,2 @@
+class Micropost < ApplicationRecord
+end

--- a/app/models/micropost.rb
+++ b/app/models/micropost.rb
@@ -1,2 +1,5 @@
 class Micropost < ApplicationRecord
+  validates :content,
+            presence: true,
+            length: { maximum: 140 }
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
   resources :users
+  resources :microposts
   root 'application#hello'
 end

--- a/db/migrate/20200808073121_create_microposts.rb
+++ b/db/migrate/20200808073121_create_microposts.rb
@@ -1,0 +1,10 @@
+class CreateMicroposts < ActiveRecord::Migration[6.0]
+  def change
+    create_table :microposts do |t|
+      t.text :content
+      t.integer :user_id
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_28_020553) do
+ActiveRecord::Schema.define(version: 2020_08_08_073121) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "microposts", force: :cascade do |t|
+    t.text "content"
+    t.integer "user_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "name"

--- a/spec/models/micropost_spec.rb
+++ b/spec/models/micropost_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Micropost, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/requests/microposts_request_spec.rb
+++ b/spec/requests/microposts_request_spec.rb
@@ -1,0 +1,4 @@
+require 'rails_helper'
+
+RSpec.describe '/microposts', type: :request do
+end


### PR DESCRIPTION
close #27, #13

## 概要

- 以下のコマンドで、model, controllerファイルを作成し、同時にmodelとrequestスペックのファイルも自動生成されました。
  - `rails g model micropost content:text user_id:integer`
  - `rails g controller microposts`
- routes.rbに、`resources :microposts` を追加
- Micropostのcontentカラムに最大文字数140のバリデーションを追加 #13
  - 本来別のIssueでしたが、変更内容がわずかだったため、同じプルリクにまとめさせていただきました。
## 修正内容の検証方法

- 各ファイルの生成を確認
- rails console 上で、141文字以上のcontentを持つMicropostが作れないことを確認

## この修正が正しい理由

- rspecとrubocopがエラーを出さないことを確認
